### PR TITLE
Fixes for sqlalchemy >= 0.8

### DIFF
--- a/elixir/__init__.py
+++ b/elixir/__init__.py
@@ -38,7 +38,7 @@ from elixir.statements import Statement
 from elixir.collection import EntityCollection, GlobalEntityCollection
 
 
-__version__ = '0.8.0dev'
+__version__ = '0.8.1dev'
 
 __all__ = ['Entity', 'EntityBase', 'EntityMeta', 'EntityCollection',
            'entities',

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -49,6 +49,10 @@ class EntityDescriptor(object):
         self.entity = entity
         self.parent = None
 
+        # set default value for options
+        self.table_args = []
+        self.table_options = {}
+
         bases = []
         for base in entity.__bases__:
             if isinstance(base, EntityMeta):
@@ -92,9 +96,6 @@ class EntityDescriptor(object):
 
         #
         self.relationships = []
-
-        # set default value for options
-        self.table_args = []
 
         # base class(es) options_defaults
         options_defaults = self.options_defaults()

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -13,7 +13,8 @@ import sqlalchemy
 from sqlalchemy import Table, Column, Integer, desc, ForeignKey, and_, \
                        ForeignKeyConstraint
 from sqlalchemy.orm import MapperExtension, mapper, object_session, \
-                           EXT_CONTINUE, polymorphic_union, ScopedSession, \
+                           EXT_CONTINUE, polymorphic_union, \
+                           scoped_session as ScopedSession, \
                            ColumnProperty
 from sqlalchemy.sql import ColumnCollection
 

--- a/elixir/entity.py
+++ b/elixir/entity.py
@@ -14,8 +14,13 @@ from sqlalchemy import Table, Column, Integer, desc, ForeignKey, and_, \
                        ForeignKeyConstraint
 from sqlalchemy.orm import MapperExtension, mapper, object_session, \
                            EXT_CONTINUE, polymorphic_union, \
-                           scoped_session as ScopedSession, \
                            ColumnProperty
+
+try:
+    from sqlalchemy.orm import ScopedSession
+except ImportError:
+    from sqlalchemy.orm import scoped_session as ScopedSession
+
 from sqlalchemy.sql import ColumnCollection
 
 import elixir

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ SVN version: <http://elixir.ematia.de/svn/elixir/trunk#egg=Elixir-dev>
       url="http://elixir.ematia.de",
       license = "MIT License",
       install_requires = [
-          "SQLAlchemy >= 0.8.0"
+          "SQLAlchemy >= 0.5.0"
       ],
       packages=find_packages(exclude=['ez_setup', 'tests', 'examples']),
       classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info >= (3,):
     extra['use_2to3'] = True
 
 setup(name="Elixir",
-      version="0.8.0",
+      version="0.8.1",
       description="Declarative Mapper for SQLAlchemy",
       long_description="""
 Elixir
@@ -33,7 +33,7 @@ SVN version: <http://elixir.ematia.de/svn/elixir/trunk#egg=Elixir-dev>
       url="http://elixir.ematia.de",
       license = "MIT License",
       install_requires = [
-          "SQLAlchemy >= 0.5.0"
+          "SQLAlchemy >= 0.8.0"
       ],
       packages=find_packages(exclude=['ez_setup', 'tests', 'examples']),
       classifiers=[


### PR DESCRIPTION
- Catch import error for scoped_session / ScopedSession
- also init using_table_options sooner to allow multi-level class hierarchy to build up the options for the class(es)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jmg/elixir/1)

<!-- Reviewable:end -->
